### PR TITLE
Made "file form name" clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Next we need to setup our ShareX to use the custom uploader
 1. From the ShareX main application we go to Destinations > Destination Settings
 2. Scroll down to 'custom uploaders' add a new profile
 3. Request type POST, the url should be http://www.example.com/upload.php
-4. File from name `d'
+4. File form name: "d" (without quotation marks)
 5. Arguments are:
     - key, this should be set to the 'secure key' you set in your config.php
-    - name, this is how the files will be named, for mine, i use '%h.%mi.%s-%d.%mo.%yy'
+    - name, this is how the files will be named, for mine, I use '%h.%mi.%s-%d.%mo.%yy'
 6. The setup is now complete, test your uploader and it 'should' work!
 ```
 


### PR DESCRIPTION
I know that this threw me when I first tried to get this set up, so I've tried to make it a little clearer. (I set file form name to literally be `d')

Also fixed a capitalisation issue.