### PR TITLE
Added config options for custom (or root) folder uploads

### DIFF
--- a/src/u/config.php
+++ b/src/u/config.php
@@ -36,4 +36,10 @@ return [
 
     /* Select lenght of random name (10 symbols by default) */
     'random_name_length' => 10,
+    
+    /* if set to false the directory_for_uploads will define the folder for uploads */
+    'upload_to_root' => false,
+    
+    /* defines an custom upload directory (default is u) */
+    'directory_for_uploads' => 'u',
 ];


### PR DESCRIPTION
In this change there are 2 new options:
- uploading to the root folder
- custom directory for files if the upload to root option is disabled
[this alone has no affect and will need an update to the upload.php which is coming soon!]