### PR TITLE
Rename API to Uploading Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ somecommand | upload
 somecommand | upload myfile.txt
 ```
 
-# Uploading with API
-Want to make something that works with your uploader? You're in luck! We've got some [documentation](UPLOADING.md).
+# Direct Uploading
+Want to upload directly using POST requests? You're in luck! We've got [some documentation](UPLOADING.md).
 
 # Screenshots
 ![Screenshot of gallery page](images/gallery.png)

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ somecommand | upload
 somecommand | upload myfile.txt
 ```
 
-# API Documentation
-Want to make something that works with your uploader? You're in luck! We've got [API documentation](API.md).
+# Uploading with API
+Want to make something that works with your uploader? You're in luck! We've got some [documentation](UPLOADING.md).
 
 # Screenshots
 ![Screenshot of gallery page](images/gallery.png)

--- a/UPLOADING.md
+++ b/UPLOADING.md
@@ -1,5 +1,5 @@
-# API Documentation
-Want to make something that works with your uploader? You're in luck! We've got API documentation.
+# Uploading Documentation
+Want to make something that works with your uploader? You're in luck! We've got some documentation.
 
 > Throughout this page, `<base_url>` will be used to refer to the `base_url` setting in your configuration, which is the URL where you can access your gallery page.
 


### PR DESCRIPTION
Created a PR to talk about whether the documentation for uploading should be called an API. It's now just called `UPLOADING.md` and the README refers to this as "Uploading with API". Let me know what you think.