### PR TITLE
Override MIME type for .apk files

### DIFF
--- a/src/rewrite.php
+++ b/src/rewrite.php
@@ -68,6 +68,13 @@ if (file_exists($file_path)) {
     $mime_type = finfo_file($finfo, $file_path);
     finfo_close($finfo);
 
+    // MIME overrides to prevent issues around MIME sniffing
+    if (preg_match("/.apk$/", $file_path)) {
+        // APKs are secret ZIPs, but serving them as ZIPs makes some
+        // android devices download them with a `.\zip` extension!
+        $mime_type = "application/vnd.android.package-archive";
+    }
+
     if ((substr($mime_type, 0, 4) === 'text' || $mime_type === 'application/json')
         && !(isset($_GET['raw']) && strtolower($_GET['raw']) === 'true' )
         && $config['enable_rich_text_viewer']) {


### PR DESCRIPTION
Fixes #119

----

The upload server uses MIME sniffing to work out what type of file it's serving. As APKs are secret ZIP files, the MIME was being set to `application/zip`.

Android devices seemed to handle this badly, saving the file as `xxx.apk.zip` as opposed to `xxx.apk`.

APKs should be served with the MIME type of `application/vnd.android.package-archive`.

We shouldn't use `octet-stream` for these, because apparently this can cause issues on some devices.

## Solution

I've added a new area for MIME overrides in `rewrite.php`. We check against the file name using regex to see if it ends with `.apk`. If so, we override the sniffed MIME type.

This area can be easily expanded in the future if more issues like this arise.