### PR TITLE
Fix testing

### DIFF
--- a/src/create_account.php
+++ b/src/create_account.php
@@ -14,7 +14,7 @@ if (file_exists($login_file_path)) {
 }
 
 session_start();
-auth_user(true);
+auth_user($config, true);
 
 if (isset($_SESSION['logged_in']) && $_SESSION['logged_in']) {
     unset($_SESSION['message']);

--- a/src/delete_files.php
+++ b/src/delete_files.php
@@ -3,7 +3,7 @@ $config = include 'merge_config.php';
 include 'functions.php';
 
 session_start();
-auth_user();
+auth_user($config);
 
 if (isset($_GET['files']) && is_array($_GET['files'])) {
     if (isset($config['enable_delete']) && $config['enable_delete']) {

--- a/src/download_update.php
+++ b/src/download_update.php
@@ -4,7 +4,7 @@ include 'functions.php';
 $config = include 'merge_config.php';
 
 session_start();
-auth_user();
+auth_user($config);
 
 if (!isset($config['enable_updater']) || !$config['enable_updater']) {
     header('Location: '.$config['base_url']);

--- a/src/functions.php
+++ b/src/functions.php
@@ -56,8 +56,7 @@ function join_paths() {
     return $protocol_str.$path_joined;
 }
 
-function create_webmanifest() {
-    $config = include 'merge_config.php';
+function create_webmanifest($config) {
     $base_host = parse_url($config['base_url'], PHP_URL_PATH);
     $manifest = [
         'name' => $config['page_title'],
@@ -93,9 +92,7 @@ function create_webmanifest() {
     }
 }
 
-function get_file_target($original_file_name, $new_name) {
-    $config = include 'merge_config.php';
-
+function get_file_target($original_file_name, $new_name, $config) {
     $extension = pathinfo($original_file_name, PATHINFO_EXTENSION);
     $target = null;
     $first_run = true;
@@ -247,9 +244,7 @@ function show_error_page($message) {
     die();
 }
 
-function auth_user($ip_only=false){
-    $config = include 'merge_config.php';
-    
+function auth_user($config, $ip_only=false){
     if(
         !empty($config['allowed_ips']) && 
         !in_array(get_ip(), $config['allowed_ips'])

--- a/src/generate_custom_uploader_file.php
+++ b/src/generate_custom_uploader_file.php
@@ -3,7 +3,7 @@
     include 'functions.php';
     
     session_start();
-    auth_user();
+    auth_user($config);
 
     $result_json = [
         'Name' => "{$config['page_title']}",

--- a/src/generate_shell_uploader.php
+++ b/src/generate_shell_uploader.php
@@ -4,7 +4,7 @@ $config = include 'merge_config.php';
 include 'functions.php';
 
 session_start();
-auth_user();
+auth_user($config);
 
 $upload_url = join_paths($config['base_url'], 'upload_text.php');
 $key = join_paths($config['secure_key']);

--- a/src/generate_zip_of_files.php
+++ b/src/generate_zip_of_files.php
@@ -3,7 +3,7 @@ $config = include 'merge_config.php';
 include 'functions.php';
 
 session_start();
-auth_user();
+auth_user($config);
 
 ini_set("memory_limit", "-1");
 set_time_limit(0);

--- a/src/index.php
+++ b/src/index.php
@@ -2,9 +2,9 @@
 $config = include 'merge_config.php';
 include 'functions.php';
 session_start();
-auth_user();
+auth_user($config);
 
-create_webmanifest();
+create_webmanifest($config);
 
 if (!empty($_SESSION) && isset($_SESSION['delete_release']) && $_SESSION['delete_release']) {
     delete_files(join_paths(getcwd(), 'release'));

--- a/src/login.php
+++ b/src/login.php
@@ -19,7 +19,7 @@ if (!file_exists($login_file_path)) {
 }
 
 session_start();
-auth_user(true);
+auth_user($config, true);
 
 if (isset($_SESSION['logged_in']) && $_SESSION['logged_in']) {
     unset($_SESSION['message']);
@@ -46,7 +46,7 @@ if (isset($_COOKIE['rememberme_authtoken']) && isset($login_file['tokens'])) {
     file_put_contents($login_file_path, json_encode($login_file));
 }
 
-create_webmanifest();
+create_webmanifest($config);
 
 ?>
 <!DOCTYPE html>

--- a/src/logout.php
+++ b/src/logout.php
@@ -4,7 +4,7 @@ $config = include 'merge_config.php';
 include 'functions.php';
 
 session_start();
-auth_user();
+auth_user($config);
 
 log_out();
 header('Location: '.join_paths($config['base_url'], 'login'));

--- a/src/register.php
+++ b/src/register.php
@@ -27,7 +27,7 @@ if (isset($_SESSION['logged_in']) && $_SESSION['logged_in']) {
     die();
 }
 
-create_webmanifest();
+create_webmanifest($config);
 
 ?>
 <!DOCTYPE html>

--- a/src/rename_file.php
+++ b/src/rename_file.php
@@ -3,7 +3,7 @@ $config = include 'merge_config.php';
 include 'functions.php';
 
 session_start();
-auth_user();
+auth_user($config);
 
 if (isset($config['enable_rename']) && $config['enable_rename']) {
     if (isset($_GET['oldname']) && isset($_GET['newname'])) {
@@ -19,9 +19,9 @@ if (isset($config['enable_rename']) && $config['enable_rename']) {
             $newfile_pathinfo = pathinfo($newfile_basename);
             $extension_exists = isset($newfile_pathinfo['extension']) && $newfile_pathinfo['extension'] !== '';
             if ($extension_exists) {
-                $target = get_file_target($newfile_basename, false, $newfile_pathinfo['filename']);
+                $target = get_file_target($newfile_basename, false, $newfile_pathinfo['filename'], $config);
             } else {
-                $target = get_file_target(basename($old_path), false, $newfile_pathinfo['filename']);
+                $target = get_file_target(basename($old_path), false, $newfile_pathinfo['filename'], $config);
             }
 
             if (rename($old_path, $target)) {

--- a/src/update.php
+++ b/src/update.php
@@ -10,8 +10,10 @@ if (!file_exists(dirname(__FILE__, 2).'/'.'functions.php')) {
 
 include '../functions.php';
 
+$config = include '../merge_config.php';
+
 session_start();
-auth_user();
+auth_user($config);
 
 // Check that this isn't a rollback update to not overwrite rollback files
 $update_version_path = join_paths(getcwd(), 'VERSION');
@@ -117,6 +119,7 @@ foreach ($OPTIONAL_FILES as $file) {
     }
 }
 
+// Reinclude updated config
 $config = include '../merge_config.php';
 
 foreach ($UPDATE_FILES as $file) {

--- a/src/upload.php
+++ b/src/upload.php
@@ -25,16 +25,16 @@ if (isset($_POST['key'])) {
 
         switch ($config['sharex_upload_naming_scheme']) {
             case 'keep':
-                $target = get_file_target($_FILES['fileupload']['name'], $filename);
+                $target = get_file_target($_FILES['fileupload']['name'], $filename, $config);
                 break;
             case 'provided':
-                $target = get_file_target($_FILES['fileupload']['name'], $_POST['name']);
+                $target = get_file_target($_FILES['fileupload']['name'], $_POST['name'], $config);
                 break;
             case 'date':
-                $target = get_file_target($_FILES['fileupload']['name'], date($config['upload_date_format']));
+                $target = get_file_target($_FILES['fileupload']['name'], date($config['upload_date_format']), $config);
                 break;
             default:
-                $target = get_file_target($_FILES['fileupload']['name'], '');
+                $target = get_file_target($_FILES['fileupload']['name'], '', $config);
                 break;
         }
 
@@ -65,13 +65,13 @@ if (isset($_POST['key'])) {
 
     switch ($config['gallery_upload_naming_scheme']) {
         case 'keep':
-            $target = get_file_target($_FILES['fileupload']['name'], $filename);
+            $target = get_file_target($_FILES['fileupload']['name'], $filename, $config);
             break;
         case 'date':
-            $target = get_file_target($_FILES['fileupload']['name'], date($config['upload_date_format']));
+            $target = get_file_target($_FILES['fileupload']['name'], date($config['upload_date_format']), $config);
             break;
         default:
-            $target = get_file_target($_FILES['fileupload']['name'], '');
+            $target = get_file_target($_FILES['fileupload']['name'], '', $config);
             break;
     }
 

--- a/src/upload_text.php
+++ b/src/upload_text.php
@@ -31,12 +31,12 @@ if (isset($_POST['key'])) {
 
         if ($filename_no_extension === '') {
             if ($config['text_upload_default_naming_scheme'] === 'date') {
-                $target = get_file_target($file_basename, date($config['upload_date_format']));
+                $target = get_file_target($file_basename, date($config['upload_date_format']), $config);
             } else {
-                $target = get_file_target($file_basename, '');
+                $target = get_file_target($file_basename, '', $config);
             }
         } else {
-            $target = get_file_target($file_basename, $filename_no_extension);
+            $target = get_file_target($file_basename, $filename_no_extension, $config);
         }
 
         $dir_path = join_paths(
@@ -74,12 +74,12 @@ if (isset($_POST['key'])) {
 
     if ($filename_no_extension === '') {
         if ($config['text_upload_default_naming_scheme'] === 'date') {
-            $target = get_file_target($file_basename, date($config['upload_date_format']));
+            $target = get_file_target($file_basename, date($config['upload_date_format']), $config);
         } else {
-            $target = get_file_target($file_basename, '');
+            $target = get_file_target($file_basename, '', $config);
         }
     } else {
-        $target = get_file_target($file_basename, $filename_no_extension);
+        $target = get_file_target($file_basename, $filename_no_extension, $config);
     }
 
     $dir_path = join_paths(

--- a/src/verify_login.php
+++ b/src/verify_login.php
@@ -4,7 +4,7 @@ $config = include 'merge_config.php';
 include 'functions.php';
 
 session_start();
-auth_user(true);
+auth_user($config, true);
 
 if (isset($_SESSION['logged_in']) && $_SESSION['logged_in']) {
     unset($_SESSION['message']);

--- a/tests/FileNameTest.php
+++ b/tests/FileNameTest.php
@@ -24,7 +24,7 @@ final class FileNameTest extends TestCase
         $original_file_name = "TestPngFile.png";
 
         $correct = $original_file_name;
-        $test = get_file_target($original_file_name, '');
+        $test = get_file_target($original_file_name, '', $GLOBALS['config']);
 
         $this->assertEquals(
             pathinfo($correct, PATHINFO_EXTENSION),
@@ -39,7 +39,7 @@ final class FileNameTest extends TestCase
         $post_name = "07.53.17-08.11.19";
 
         $correct = $original_file_name;
-        $test = get_file_target($original_file_name, $post_name);
+        $test = get_file_target($original_file_name, $post_name, $GLOBALS['config']);
 
         $this->assertEquals(
             pathinfo($correct, PATHINFO_EXTENSION),
@@ -54,7 +54,7 @@ final class FileNameTest extends TestCase
         $post_name = "testname";
 
         $correct = $post_name.'.png';
-        $test = get_file_target($original_file_name, $post_name);
+        $test = get_file_target($original_file_name, $post_name, $GLOBALS['config']);
 
         $this->assertEquals(
             $correct,


### PR DESCRIPTION
All GitHub Actions tests seem to be failing now, so this fixes that. This PR updates the version of PHPUnit we use, and also accounts for an issue that occurs due to functions required in tests loading the `merge-config.php` file. Since `merge-config.php` now checks if a `config.php` file exists, it doesn't allow tests to proceed on a clean testing environment. As far as I can tell, the best way to get around this is to just pass the config object to functions that need config instead of loading it right in the function.

Let me know what you think.