### PR TITLE
Fix Firefox theme loading

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -25,7 +25,7 @@ if (!empty($_SESSION) && isset($_SESSION['delete_release']) && $_SESSION['delete
     <link rel="preload" href="js/setTheme.js" as="script">
 
     <link rel="stylesheet" href="css/toggle-bootstrap.min.css">
-    <link rel="stylesheet" href="css/toggle-bootstrap-dark-overlay.min.css" onload="this.disabled = true; window.__darkCssLoaded = true; if (window.__updateTheme) { window.__updateTheme(); }">
+    <link rel="stylesheet" href="css/toggle-bootstrap-dark-overlay.min.css" onload="window.__darkCssLoaded = true; if (window.__updateTheme) { window.__updateTheme(); }">
     <link
         href="https://cdn.datatables.net/1.10.21/css/dataTables.bootstrap4.min.css"
         rel="stylesheet"


### PR DESCRIPTION
Fixes #128.

For future reference (and maybe this'll show up in a Google search for someone someday):
In Firefox, the onload listener in link tags appears to be run not just when the tag is loaded, but also whenever the tag is marked as `myTag.disabled = false`.

In our case, this caused an infinite loop whenever dark mode was loaded, since the onload listener would mark the tag as disabled and then would be reenabled by the updateTheme function.