### PR TITLE
Fix dashboard performance

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -7,11 +7,10 @@ function display_alert($text, $type) {
 }
 
 function is_image($file) {
-    $image_formats = ['image/png', 'image/jpeg', 'image/gif', 'image/svg+xml'];
-    if (!in_array($file, $image_formats))
-        return false;
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#Supported_image_formats
+    $image_formats = ['apng', 'gif', 'jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp', 'png', 'svg','webp'];
 
-    return true;
+    return in_array($file, $image_formats);
 }
 
 function generate_random_name($type, $length) {

--- a/src/index.php
+++ b/src/index.php
@@ -67,7 +67,6 @@ if (!empty($_SESSION) && isset($_SESSION['delete_release']) && $_SESSION['delete
             }
 
             $files = preg_grep('/^([^.])/', scandir($dir_path));
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
 
             if (!empty($_SESSION) && isset($_SESSION['message']) && isset($_SESSION['type'])) {
                 echo display_alert($_SESSION['message'], $_SESSION['type']);
@@ -173,7 +172,13 @@ if (!empty($_SESSION) && isset($_SESSION['delete_release']) && $_SESSION['delete
 
                 if (is_dir($file)) {
                     unset($files[$key]);
-                } else { ?>
+                } else { 
+                    
+                    // Info
+                    $filesize = bytes_to_string(filesize($file_path));
+                    $filemodifiedtime = filemtime($file_path);
+                    $extension = pathinfo($file_path, PATHINFO_EXTENSION);
+                ?>
                     <tr data-filename="<?php echo $file; ?>" >
                         <td>
                             <?php if ($config['enable_bulk_operations']) { ?>
@@ -183,7 +188,7 @@ if (!empty($_SESSION) && isset($_SESSION['delete_release']) && $_SESSION['delete
                                 </div>
                             <?php } ?>
                             <a target="_blank" href="<?php echo join_paths($config['base_url'], $config['upload_access_path'], $file); ?>"
-                                <?php if ($config['enable_tooltip'] && is_image(finfo_file($finfo, $file_path))) { ?>
+                                <?php if ($config['enable_tooltip'] && is_image($extension)) { ?>
                                     data-toggle="tooltip" data-html="true" data-placement="right" title="<img src='<?php echo join_paths($config['base_url'], $config['upload_access_path'], $file);
                                 ?>' width='150px' alt='<?php echo $file; ?>'>"
                                 <?php } ?>>
@@ -191,13 +196,13 @@ if (!empty($_SESSION) && isset($_SESSION['delete_release']) && $_SESSION['delete
                             </a>
                         </td>
                         <td>
-                            <?php echo bytes_to_string(filesize($file_path)); ?>
+                            <?php echo $filesize; ?>
                         </td>
                         <td>
-                            <?php echo filemtime($file_path) ?>
+                            <?php echo $filemodifiedtime; ?>
                         </td>
                         <td>
-                            <?php echo pathinfo($file_path, PATHINFO_EXTENSION); ?>
+                            <?php echo $extension; ?>
                         </td>
                         <?php if ($config['enable_rename'] || $config['enable_delete']) { ?>
                             <td class="text-center">


### PR DESCRIPTION
Fixes #129.

At the moment, this PR only applies the first fix I detailed in #129. @davwheat can take a look and let me know if it fixes the issue, and if there's still some performance to be desired, I'll work on implementing the rest of the fixes.

- [x] Most likely, if you run ls -la on that directory right now, it won't take 5 minutes. This makes this problem a bit more confusing, since ls will be fetching the same information that we are. My guess is that since we use finfo_file to read file info to determine whether to draw a tooltip, that's the main bottleneck. Since finfo reads MIME types, it has to open and read the first few bytes of each file, which is much slower than just getting info like size from the file system. This can be fixed by just checking via file extension.
- [ ] It's reasonable to suspect that reading file info might be slow itself even without finfo_file. This could be fixed by creating an index of all uploads that has some basic info about each file. This means that the page will just have to read from the index instead of scanning the directory each time. The index would be updated whenever a file is uploaded, renamed, or deleted. This means that users wouldn't be able to really change the files manually, because it would break the index. In addition to generating the index on first load, users could be given the object to regenerate the index if they have to change something (like with a button on the dashboard). Index mode would be an off-by-default configuration option.
- [ ] Finally, there's likely a performance drawback from generating all the HTML for the data table at once and sending it over. Luckily, DataTables allows for server side processing. This means that server would be doing all the sorting and would just send over the rows to display. Using this along with index mode would greatly speed up time to first byte, as well as page load time. This would also be in a configuration option.